### PR TITLE
Fix all prices format (adding "usd" sufix)

### DIFF
--- a/src/Components/Misc/CardProductVertical.jsx
+++ b/src/Components/Misc/CardProductVertical.jsx
@@ -98,7 +98,7 @@ const CardProductVertical = (props) => {
              
             <div className="flex justify-between  ">
               <span className="text-xl font-bold pt-3 px-3 text-gray-700  ">
-                ${Number(price).toFixed(2)}
+                ${Number(price).toFixed(2)} usd
               </span>{" "}
               <div className="flex p-1  ">
                 <button

--- a/src/Components/Misc/CartIconGlobal.jsx
+++ b/src/Components/Misc/CartIconGlobal.jsx
@@ -121,7 +121,7 @@ const CartIconGlobal = () => {
                                     </span>
                                     <span className="text-lg">X</span>
                                     <span className=" text-lg font-medium color-green">
-                                      ${Number(product.price).toFixed(2)}
+                                      ${Number(product.price).toFixed(2)} usd
                                     </span>
                                   </div>
                                 </div>
@@ -172,7 +172,7 @@ const CartIconGlobal = () => {
                         <div className="flex py-2 justify-between">
                           <span className="subtitle-2 px-2">Subtotal</span>
                           <span className="subtitle-2 px-2">
-                            ${Number(getTotalPrice()).toFixed(2)}
+                            ${Number(getTotalPrice()).toFixed(2)} usd
                           </span>
                         </div>
                         <hr className="separator  " />

--- a/src/Components/Misc/ProductRestaurantDELETE.jsx
+++ b/src/Components/Misc/ProductRestaurantDELETE.jsx
@@ -74,7 +74,7 @@ const ProductRestaurant = (props) => {
                 {product.name}
               </span>
               <span className="text-md -mt-3 px-3 pb-5 color">
-                {product.price.toFixed(2)} USD
+                {product.price.toFixed(2)} usd
               </span>
               <br />
               <button className="flex space-x-1">

--- a/src/Pages/frontend/Cart.jsx
+++ b/src/Pages/frontend/Cart.jsx
@@ -98,7 +98,7 @@ const Cart = () => {
                       </div>
                     </td>
                     <td className="subtitle">
-                      {Number(product.quantity * product.price).toFixed(2)}
+                      {Number(product.quantity * product.price).toFixed(2)} usd
                     </td>
                   </tr>
                 );

--- a/src/Pages/frontend/CheckOut.jsx
+++ b/src/Pages/frontend/CheckOut.jsx
@@ -450,7 +450,7 @@ const CheckOut = () => {
                                   </span>
                                   <span className="text-2xl">X</span>
                                   <span className=" text-2xl font-medium color-green">
-                                  ${Number(product.price).toFixed(2)}
+                                  ${Number(product.price).toFixed(2)} usd
                                   </span>
                                 </div>
                               </div>
@@ -494,18 +494,18 @@ const CheckOut = () => {
 
                       <hr className="separator  " />
                       <div className="border-2 flex lg:mx-14 flex-col border-gray-400 border-dashed h-30 my-3 p-3">
-                        Productos: ${Number(getTotalPrice()).toFixed(2)}
+                        Productos: ${Number(getTotalPrice()).toFixed(2)} usd
                         <br />
                         <span className="py-1">
                           {" "}
-                          Costo de envío: ${Number(deliveryCost()).toFixed(2)}
+                          Costo de envío: ${Number(deliveryCost()).toFixed(2)} usd
                         </span>
                         <span className="py-1">
-                          YaVoy fee: ${Number(fee()).toFixed(2)}
+                          YaVoy fee: ${Number(fee()).toFixed(2)} usd
                         </span>
                         <hr className="py-2" />
                         <span className="text-lg font-bold">
-                          Total: $ {Number(getTotalPriceFinal()).toFixed(2)}
+                          Total: $ {Number(getTotalPriceFinal()).toFixed(2)} usd
                         </span>
                       </div>
 

--- a/src/Pages/frontend/ProductDetailPage.jsx
+++ b/src/Pages/frontend/ProductDetailPage.jsx
@@ -134,7 +134,7 @@ const ProductDetailPage = (props) => {
                       <span>CATEGORÍA: {product.category?.name}</span>
                     </div>
                     <span className="text-color font-bold text-4xl mt-3">
-                      ${Number(product.price).toFixed(2)}
+                      ${Number(product.price).toFixed(2)} usd
                     </span>
 
                     <span


### PR DESCRIPTION
solves click up task: https://app.clickup.com/t/8678g6b4h

![price ok](https://github.com/YaVoyCuba/yavoy-frontend-react/assets/47121318/017bd5ac-3594-4563-a6e3-3cb0116edf9d)

![prod](https://github.com/YaVoyCuba/yavoy-frontend-react/assets/47121318/421fe451-86eb-4798-a92b-2845b0cb9b76)

![prod 2](https://github.com/YaVoyCuba/yavoy-frontend-react/assets/47121318/562e4478-13e3-4942-9fba-125c97d1c7e3)